### PR TITLE
EDF time slicing

### DIFF
--- a/src/cai_lab_to_nwb/zaki_2024/interfaces/miniscope_imaging_interface.py
+++ b/src/cai_lab_to_nwb/zaki_2024/interfaces/miniscope_imaging_interface.py
@@ -6,6 +6,7 @@ import json
 import datetime
 
 from copy import deepcopy
+from typing import Union
 from pathlib import Path
 from typing import Literal, Optional
 
@@ -15,6 +16,101 @@ from pynwb import NWBFile
 
 from neuroconv.datainterfaces.ophys.baseimagingextractorinterface import BaseImagingExtractorInterface
 from neuroconv.utils import DeepDict, dict_deep_update
+
+
+def get_session_start_time(folder_path: Union[str, Path]):
+    """
+    Retrieve the session start time from metadata in the specified folder.
+
+    Parameters:
+    -----------
+    folder_path : Union[str, Path]
+        Path to the main session folder, expected to contain a "metaData.json" file with recording start time details.
+
+    Returns:
+    --------
+    datetime.datetime
+        A datetime object representing the session start time, based on the metadata's year, month, day, hour, minute,
+        second, and millisecond fields.
+
+    Raises:
+    -------
+    AssertionError
+        If the "metaData.json" file is not found in the specified folder path.
+    KeyError
+        If any of the required time fields ("year", "month", "day", "hour", "minute", "second", "msec") are missing
+        from the metadata.
+
+    Notes:
+    ------
+    - The function expects a "recordingStartTime" key in the metadata JSON, which contains start time details.
+      If not present, the top-level JSON object is assumed to contain the time information.
+    - The "msec" field in the metadata is converted from milliseconds to microseconds for compatibility with the datetime
+      microsecond field.
+    """
+    general_metadata_json = folder_path / "metaData.json"
+    assert general_metadata_json.exists(), f"General metadata json not found in {folder_path}"
+    ## Read metadata
+    with open(general_metadata_json) as f:
+        general_metadata = json.load(f)
+
+    if "recordingStartTime" in general_metadata:
+        start_time_info = general_metadata["recordingStartTime"]
+    else:
+        start_time_info = general_metadata
+
+    required_keys = ["year", "month", "day", "hour", "minute", "second", "msec"]
+    for key in required_keys:
+        if key not in start_time_info:
+            raise KeyError(f"Missing required key '{key}' in the metadata")
+
+    session_start_time = datetime.datetime(
+        year=start_time_info["year"],
+        month=start_time_info["month"],
+        day=start_time_info["day"],
+        hour=start_time_info["hour"],
+        minute=start_time_info["minute"],
+        second=start_time_info["second"],
+        microsecond=start_time_info["msec"] * 1000,  # Convert milliseconds to microseconds
+    )
+
+    return session_start_time
+
+
+def get_miniscope_timestamps(miniscope_folder_path: Union[str, Path]):
+    """
+    Retrieve the Miniscope timestamps from a CSV file and convert them to seconds.
+
+    Parameters:
+    -----------
+    miniscope_folder_path : Union[str, Path]
+        Path to the folder containing the Miniscope "timeStamps.csv" file, which includes timestamps in milliseconds.
+
+    Returns:
+    --------
+    np.ndarray
+        A NumPy array containing the Miniscope timestamps in seconds, converted from the original milliseconds.
+
+    Raises:
+    -------
+    AssertionError
+        If the "timeStamps.csv" file is not found in the specified Miniscope folder path.
+
+    Notes:
+    ------
+    - This function expects the timestamps CSV file to have a column named "Time Stamp (ms)" with values in milliseconds.
+    - The timestamps are converted from milliseconds to seconds for compatibility with other functions that expect time
+      values in seconds.
+    """
+    timestamps_file_path = miniscope_folder_path / "timeStamps.csv"
+    assert timestamps_file_path.exists(), f"Miniscope timestamps file not found in {miniscope_folder_path}"
+    import pandas as pd
+
+    timetsamps_df = pd.read_csv(timestamps_file_path)
+    timestamps_milliseconds = timetsamps_df["Time Stamp (ms)"].values.astype(float)
+    timestamps_seconds = timestamps_milliseconds / 1000.0
+
+    return np.asarray(timestamps_seconds)
 
 
 class MiniscopeImagingExtractor(MultiImagingExtractor):
@@ -205,36 +301,6 @@ class MiniscopeImagingInterface(BaseImagingExtractorInterface):
 
         self.photon_series_type = "OnePhotonSeries"
 
-    def _get_session_start_time(self):
-        general_metadata_json = self.session_folder / "metaData.json"
-        assert general_metadata_json.exists(), f"General metadata json not found in {self.session_folder}"
-
-        ## Read metadata
-        with open(general_metadata_json) as f:
-            general_metadata = json.load(f)
-
-        if "recordingStartTime" in general_metadata:
-            start_time_info = general_metadata["recordingStartTime"]
-        else:
-            start_time_info = general_metadata
-
-        required_keys = ["year", "month", "day", "hour", "minute", "second", "msec"]
-        for key in required_keys:
-            if key not in start_time_info:
-                raise KeyError(f"Missing required key '{key}' in the metadata")
-
-        session_start_time = datetime.datetime(
-            year=start_time_info["year"],
-            month=start_time_info["month"],
-            day=start_time_info["day"],
-            hour=start_time_info["hour"],
-            minute=start_time_info["minute"],
-            second=start_time_info["second"],
-            microsecond=start_time_info["msec"] * 1000,  # Convert milliseconds to microseconds
-        )
-
-        return session_start_time
-
     def get_metadata(self) -> DeepDict:
         from neuroconv.tools.roiextractors import get_nwb_imaging_metadata
 
@@ -243,7 +309,8 @@ class MiniscopeImagingInterface(BaseImagingExtractorInterface):
         metadata = dict_deep_update(metadata, default_metadata)
         metadata["Ophys"].pop("TwoPhotonSeries", None)
 
-        session_start_time = self._get_session_start_time()
+        session_start_time = get_session_start_time(folder_path=self.session_folder)
+
         metadata["NWBFile"].update(session_start_time=session_start_time)
 
         device_metadata = metadata["Ophys"]["Device"][0]
@@ -267,22 +334,13 @@ class MiniscopeImagingInterface(BaseImagingExtractorInterface):
         return metadata_schema
 
     def get_original_timestamps(self) -> np.ndarray:
-
-        timestamps_file_path = self.miniscope_folder / "timeStamps.csv"
-        assert timestamps_file_path.exists(), f"Miniscope timestamps file not found in {self.miniscope_folder}"
-
-        import pandas as pd
-
-        timetsamps_df = pd.read_csv(timestamps_file_path)
-        timestamps_milliseconds = timetsamps_df["Time Stamp (ms)"].values.astype(float)
-        timestamps_seconds = timestamps_milliseconds / 1000.0
-
+        timestamps_seconds = get_miniscope_timestamps(miniscope_folder_path=self.miniscope_folder)
         # Shift when the first timestamp is negative
-        # TODO: Figure why, I copied from miniscope
+        # TODO: Figure why, I copied from Miniscope. Need to shift also session_start_time
         if timestamps_seconds[0] < 0.0:
             timestamps_seconds += abs(timestamps_seconds[0])
 
-        return np.asarray(timestamps_seconds)
+        return timestamps_seconds
 
     def add_to_nwbfile(
         self,
@@ -308,7 +366,7 @@ class MiniscopeImagingInterface(BaseImagingExtractorInterface):
         imaging_extractor.set_times(times=miniscope_timestamps)
 
         device_metadata = metadata["Ophys"]["Device"][0]
-        # Cast to string because miniscope extension requires so
+        # Cast to string because Miniscope extension requires so
         device_metadata["gain"] = str(device_metadata["gain"])
         device_metadata.pop("ewl")
         add_miniscope_device(nwbfile=nwbfile, device_metadata=device_metadata)

--- a/src/cai_lab_to_nwb/zaki_2024/interfaces/zaki_2024_edf_interface.py
+++ b/src/cai_lab_to_nwb/zaki_2024/interfaces/zaki_2024_edf_interface.py
@@ -11,24 +11,47 @@ class Zaki2024EDFInterface(BaseDataInterface):
     def __init__(
         self,
         file_path: Path,
-        start_datetime_timestamp: datetime = None,
-        stop_datetime_timestamp: datetime = None,
         verbose: bool = False,
     ):
         self.file_path = Path(file_path)
-        self.start_datetime_timestamp = start_datetime_timestamp
-        self.stop_datetime_timestamp = stop_datetime_timestamp
         self.verbose = verbose
-        super().__init__(
-            file_path=file_path,
-            start_datetime_timestamp=start_datetime_timestamp,
-            stop_datetime_timestamp=stop_datetime_timestamp,
-        )
+        super().__init__(file_path=file_path)
 
     def add_to_nwbfile(
-        self, nwbfile: NWBFile, stub_test: bool = False, stub_frames: int = 100, **conversion_options
+        self,
+        nwbfile: NWBFile,
+        stub_test: bool = False,
+        stub_frames: int = 100,
+        start_datetime_timestamp: datetime = None,
+        stop_datetime_timestamp: datetime = None,
+        **conversion_options,
     ) -> NWBFile:
+        """
+        Adds data from EEG, EMG, temperature, and activity channels to an NWBFile.
 
+        Parameters
+        ----------
+        nwbfile : NWBFile
+            The NWBFile object to which data will be added.
+        stub_test : bool, optional
+            If True, loads only a subset of frames (controlled by `stub_frames` parameter)
+            to facilitate testing and faster execution. Default is False.
+        stub_frames : int, optional
+            The number of frames to load if `stub_test` is True. Default is 100.
+        start_datetime_timestamp : datetime, optional
+            The starting timestamp for slicing the data. If specified, data will be included
+            only from this time onward. Default is None, which includes data from the start.
+        stop_datetime_timestamp : datetime, optional
+            The ending timestamp for slicing the data. If specified, data will be included
+            only up to this time. Default is None, which includes data until the end.
+        **conversion_options
+            Additional options for data conversion (not currently used directly in this function).
+
+        Returns
+        -------
+        NWBFile
+            The NWBFile object with added data and metadata from the specified channels.
+        """
         channels_dict = {
             "Temp": {
                 "name": "TemperatureSignal",
@@ -57,18 +80,21 @@ class Zaki2024EDFInterface(BaseDataInterface):
         edf_reader = read_raw_edf(input_fname=self.file_path, verbose=self.verbose)
         data, times = edf_reader.get_data(picks=list(channels_dict.keys()), return_times=True)
         data = data.astype("float32")
-        if self.start_datetime_timestamp is not None:
+        if start_datetime_timestamp is not None:
             # Get edf start_time in datetime format
             edf_start_time = edf_reader.info["meas_date"]
             # Convert relative edf timestamps to datetime timestamps
             edf_start_time = edf_start_time.replace(tzinfo=None)
             edf_datetime_timestamps = [edf_start_time + timedelta(seconds=t) for t in times]
             # Find the indices of the timestamps within the time range
-            start_idx = np.searchsorted(edf_datetime_timestamps, self.start_datetime_timestamp, side="left")
-            end_idx = np.searchsorted(edf_datetime_timestamps, self.stop_datetime_timestamp, side="right")
+            start_idx = np.searchsorted(edf_datetime_timestamps, start_datetime_timestamp, side="left")
+            end_idx = np.searchsorted(edf_datetime_timestamps, stop_datetime_timestamp, side="right")
+            starting_time = edf_datetime_timestamps[start_idx] - start_datetime_timestamp
+            starting_time = starting_time.total_seconds()
         else:
             start_idx = 0
             end_idx = -1
+            starting_time = times[start_idx]
 
         # Slice the data and timestamps within the time range
         if stub_test:
@@ -78,7 +104,9 @@ class Zaki2024EDFInterface(BaseDataInterface):
 
         for channel_index, channel_name in enumerate(channels_dict.keys()):
             time_series_kwargs = channels_dict[channel_name].copy()
-            time_series_kwargs.update(data=data[channel_index], starting_time=0.0, rate=edf_reader.info["sfreq"])
+            time_series_kwargs.update(
+                data=data[channel_index], starting_time=starting_time, rate=edf_reader.info["sfreq"]
+            )
             time_series = TimeSeries(**time_series_kwargs)
             nwbfile.add_acquisition(time_series)
 

--- a/src/cai_lab_to_nwb/zaki_2024/zaki_2024_convert_session.py
+++ b/src/cai_lab_to_nwb/zaki_2024/zaki_2024_convert_session.py
@@ -188,12 +188,18 @@ def session_to_nwb(
             dict(
                 EDFSignals=dict(
                     file_path=edf_file_path,
+                )
+            )
+        )
+        conversion_options.update(
+            dict(
+                EDFSignals=dict(
+                    stub_test=stub_test,
                     start_datetime_timestamp=start_datetime_timestamp,
                     stop_datetime_timestamp=stop_datetime_timestamp,
                 )
             )
         )
-        conversion_options.update(dict(EDFSignals=dict(stub_test=stub_test)))
     elif verbose and not include_eeg_emg_signals:
         print(f"The EEG, EMG, Temperature and Activity signals will not be included for session {session_id}")
     elif verbose and not edf_file_path.is_file():

--- a/src/cai_lab_to_nwb/zaki_2024/zaki_2024_convert_session.py
+++ b/src/cai_lab_to_nwb/zaki_2024/zaki_2024_convert_session.py
@@ -171,7 +171,6 @@ def session_to_nwb(
         print(f"No freezing output csv file found at {freezing_output_file_path}")
 
     # Add EEG, EMG, Temperature and Activity signals
-    # TODO discuss how to slice this data
     datetime_obj = datetime.strptime(date_str, "%Y_%m_%d")
     reformatted_date_str = datetime_obj.strftime("_%m%d%y")
     edf_file_path = data_dir_path / "Ca_EEG_EDF" / (subject_id + "_EDF") / (subject_id + reformatted_date_str + ".edf")

--- a/src/cai_lab_to_nwb/zaki_2024/zaki_2024_convert_session.py
+++ b/src/cai_lab_to_nwb/zaki_2024/zaki_2024_convert_session.py
@@ -10,7 +10,7 @@ import json
 from neuroconv.utils import load_dict_from_file, dict_deep_update
 
 from zaki_2024_nwbconverter import Zaki2024NWBConverter
-from interfaces.miniscope_imaging_interface import get_miniscope_timestamps, get_session_start_time
+from interfaces.miniscope_imaging_interface import get_miniscope_timestamps, get_recording_start_time
 
 
 def get_miniscope_folder_path(folder_path: Union[str, Path]):
@@ -46,17 +46,17 @@ def get_miniscope_folder_path(folder_path: Union[str, Path]):
         return None
 
 
-def get_edf_slicing_time_range(folder_path: Union[str, Path], miniscope_folder_path: Union[str, Path]):
+def get_edf_slicing_time_range(miniscope_metadata_json: Union[str, Path], timestamps_file_path: Union[str, Path]):
     """
     Calculate the time range for EDF slicing based on session start time and Miniscope timestamps.
 
     Parameters:
     -----------
-    folder_path : Union[str, Path]
-        Path to the session folder, which contains metadata.json file produced by Miniscope output.
+    miniscope_metadata_json : Union[str, Path]
+        Path to the metadata.json file produced by Miniscope output.
 
-    miniscope_folder_path : Union[str, Path]
-        Path to the folder containing Miniscope timeStamps.csv file.
+    timestamps_file_path : Union[str, Path]
+        Path to the Miniscope timeStamps.csv file.
 
     Returns:
     --------
@@ -66,11 +66,12 @@ def get_edf_slicing_time_range(folder_path: Union[str, Path], miniscope_folder_p
         start time adjusted by the last Miniscope timestamp.
 
     """
-    folder_path = Path(folder_path)
-    if folder_path.is_dir() and miniscope_folder_path.is_dir():
+    miniscope_metadata_json = Path(miniscope_metadata_json)
+    timestamps_file_path = Path(timestamps_file_path)
+    if miniscope_metadata_json.is_file() and timestamps_file_path.is_file():
 
-        session_start_time = get_session_start_time(folder_path=folder_path)
-        miniscope_timestamps = get_miniscope_timestamps(miniscope_folder_path=miniscope_folder_path)
+        session_start_time = get_recording_start_time(file_path=miniscope_metadata_json)
+        miniscope_timestamps = get_miniscope_timestamps(file_path=timestamps_file_path)
 
         start_datetime_timestamp = session_start_time + timedelta(seconds=miniscope_timestamps[0])
         stop_datetime_timestamp = session_start_time + timedelta(seconds=miniscope_timestamps[-1])
@@ -176,9 +177,12 @@ def session_to_nwb(
     edf_file_path = data_dir_path / "Ca_EEG_EDF" / (subject_id + "_EDF") / (subject_id + reformatted_date_str + ".edf")
 
     if edf_file_path.is_file() and include_eeg_emg_signals:
-
+        miniscope_metadata_json = folder_path / "metaData.json"
+        assert miniscope_metadata_json.exists(), f"General metadata json not found in {folder_path}"
+        timestamps_file_path = miniscope_folder_path / "timeStamps.csv"
+        assert timestamps_file_path.exists(), f"Miniscope timestamps file not found in {miniscope_folder_path}"
         start_datetime_timestamp, stop_datetime_timestamp = get_edf_slicing_time_range(
-            folder_path=folder_path, miniscope_folder_path=miniscope_folder_path
+            miniscope_metadata_json=miniscope_metadata_json, timestamps_file_path=timestamps_file_path
         )
         source_data.update(
             dict(


### PR DESCRIPTION
Add an option for slicing edf data based on the time range of miniscope recording.

1. Get Miniscope session start time (already in datetime format in the metadata.json)
2. Get Miniscope relative timestamps and convert the first and the last timestamps in `datetime` format using the session start time
3. Input these two timestamps in edf interface
4. Get EDF recording start time in `datetime` format
5. Convert EDF relative timestamps in `datetime `format using EDF recording start time 
6. Slice EDF data inside the time range identified by Miniscope recording start time and stop time in `datetime` format
