### PR TITLE
Add imaging timestamps using new conversion option always_write_timestamps

### DIFF
--- a/src/cai_lab_to_nwb/zaki_2024/interfaces/miniscope_imaging_interface.py
+++ b/src/cai_lab_to_nwb/zaki_2024/interfaces/miniscope_imaging_interface.py
@@ -350,6 +350,7 @@ class MiniscopeImagingInterface(BaseImagingExtractorInterface):
         photon_series_index: int = 0,
         stub_test: bool = False,
         stub_frames: int = 100,
+        always_write_timestamps: bool = True,
     ):
         from ndx_miniscope.utils import add_miniscope_device
 
@@ -377,4 +378,5 @@ class MiniscopeImagingInterface(BaseImagingExtractorInterface):
             metadata=metadata,
             photon_series_type=photon_series_type,
             photon_series_index=photon_series_index,
+            always_write_timestamps=always_write_timestamps,
         )


### PR DESCRIPTION
To be reviewed after merging #15 
Add imaging timestamps using new conversion option `always_write_timestamps`