### PR TITLE
Time alignment

### DIFF
--- a/src/cai_lab_to_nwb/zaki_2024/interfaces/minian_interface.py
+++ b/src/cai_lab_to_nwb/zaki_2024/interfaces/minian_interface.py
@@ -154,7 +154,7 @@ class MinianSegmentationExtractor(SegmentationExtractor):
         accepted_list: list
             List of accepted ROI ids.
         """
-        return list(range(self.get_num_rois()))
+        return self.get_roi_ids()
 
     def get_rejected_list(self) -> list:
         """Get a list of rejected ROI ids.
@@ -312,6 +312,28 @@ class _MinianMotionCorrectedVideoExtractor(ImagingExtractor):
     def get_channel_names(self) -> list[str]:
         return ["OpticalChannel"]
 
+    def get_original_timestamps(self, stub_test: bool = False) -> list[np.ndarray]:
+        """
+        Retrieve the original unaltered timestamps for the data in this interface.
+
+        This function should retrieve the data on-demand by re-initializing the IO.
+
+        Returns
+        -------
+        timestamps : numpy.ndarray
+            The timestamps for the data stream.
+        stub_test : bool, default: False
+            This method scans through each video; a process which can take some time to complete.
+
+            To limit that scan to a small number of frames, set `stub_test=True`.
+        """
+        max_frames = 100 if stub_test else None
+        with self._video_capture(file_path=str(self.file_path)) as video:
+            # fps = video.get_video_fps()  # There is some debate about whether the OpenCV timestamp
+            # method is simply returning range(length) / fps 100% of the time for any given format
+            timestamps = video.get_video_timestamps(max_frames=max_frames)
+        return timestamps
+
     def get_video(
         self, start_frame: Optional[int] = None, end_frame: Optional[int] = None, channel: int = 0
     ) -> np.ndarray:
@@ -440,7 +462,7 @@ class MinianMotionCorrectionInterface(BaseDataInterface):
             xy_translation=xy_translation,
         )
 
-        ophys = get_module(nwbfile, "ophys")
+        ophys = get_module(nwbfile, name="ophys", description="Data processed with MiniAn software")
         if "MotionCorrection" not in ophys.data_interfaces:
             motion_correction = MotionCorrection(name="MotionCorrection")
             ophys.add(motion_correction)

--- a/src/cai_lab_to_nwb/zaki_2024/interfaces/minian_interface.py
+++ b/src/cai_lab_to_nwb/zaki_2024/interfaces/minian_interface.py
@@ -166,10 +166,6 @@ class MinianSegmentationExtractor(SegmentationExtractor):
         """
         return list()
 
-    def get_roi_ids(self) -> list:
-        dataset = self._read_zarr_group("/A.zarr")
-        return list(dataset["unit_id"])
-
     def get_traces_dict(self) -> dict:
         """Get traces as a dictionary with key as the name of the ROiResponseSeries.
 

--- a/src/cai_lab_to_nwb/zaki_2024/interfaces/miniscope_imaging_interface.py
+++ b/src/cai_lab_to_nwb/zaki_2024/interfaces/miniscope_imaging_interface.py
@@ -386,7 +386,7 @@ class MiniscopeImagingInterface(BaseImagingExtractorInterface):
 
         from neuroconv.tools.roiextractors import add_photon_series_to_nwbfile
 
-        miniscope_timestamps = self.get_original_timestamps()
+        miniscope_timestamps = self.get_timestamps()
         imaging_extractor = self.imaging_extractor
 
         if stub_test:

--- a/src/cai_lab_to_nwb/zaki_2024/interfaces/miniscope_imaging_interface.py
+++ b/src/cai_lab_to_nwb/zaki_2024/interfaces/miniscope_imaging_interface.py
@@ -370,11 +370,6 @@ class MiniscopeImagingInterface(BaseImagingExtractorInterface):
         timestamps_file_path = self.miniscope_folder / "timeStamps.csv"
         assert timestamps_file_path.exists(), f"Miniscope timestamps file not found in {self.miniscope_folder}"
         timestamps_seconds = get_miniscope_timestamps(file_path=timestamps_file_path)
-        # Shift when the first timestamp is negative
-        # TODO: Figure why, I copied from Miniscope. Need to shift also session_start_time
-        if timestamps_seconds[0] < 0.0:
-            timestamps_seconds += abs(timestamps_seconds[0])
-
         return timestamps_seconds
 
     def add_to_nwbfile(

--- a/src/cai_lab_to_nwb/zaki_2024/interfaces/zaki_2024_sleep_classification_interface.py
+++ b/src/cai_lab_to_nwb/zaki_2024/interfaces/zaki_2024_sleep_classification_interface.py
@@ -1,12 +1,13 @@
 """Primary class for converting experiment-specific behavior."""
 
-from pynwb.file import NWBFile
+import pandas as pd
+from pydantic import FilePath
+from typing import Optional, List
 
+from pynwb.file import NWBFile
+from pynwb.epoch import TimeIntervals
 from neuroconv.basedatainterface import BaseDataInterface
 from neuroconv.utils import DeepDict
-from pydantic import FilePath
-from typing import Optional
-from pynwb.epoch import TimeIntervals
 
 
 class Zaki2024SleepClassificationInterface(BaseDataInterface):
@@ -14,12 +15,14 @@ class Zaki2024SleepClassificationInterface(BaseDataInterface):
 
     keywords = ["behavior", "sleep stages"]
 
-    def __init__(self, file_path: FilePath, video_sampling_frequency: float, verbose: bool = False):
+    def __init__(self, file_path: FilePath, sampling_frequency: float, verbose: bool = False):
         # This should load the data lazily and prepare variables you need
 
         self.file_path = file_path
         self.verbose = verbose
-        self.video_sampling_frequency = video_sampling_frequency
+        self.sampling_frequency = sampling_frequency
+        self._start_times = None
+        self._stop_times = None
 
     def get_metadata(self) -> DeepDict:
         # Automatically retrieve as much metadata as possible from the source files available
@@ -27,33 +30,40 @@ class Zaki2024SleepClassificationInterface(BaseDataInterface):
 
         return metadata
 
-    def add_to_nwbfile(self, nwbfile: NWBFile, metadata: Optional[dict] = None):
-
-        import pandas as pd
-
+    def get_sleep_states_times(self):
         sleep_behavior_df = pd.read_csv(self.file_path)
 
         import numpy as np
 
         # Note this will have the first row as None
-        shifted_sleep_state = sleep_behavior_df['SleepState'].shift()
-        start_indices = np.where(sleep_behavior_df['SleepState'] != shifted_sleep_state)[0]
+        shifted_sleep_state = sleep_behavior_df["SleepState"].shift()
+        start_indices = np.where(sleep_behavior_df["SleepState"] != shifted_sleep_state)[0]
         stop_indices = [i - 1 for i in start_indices[1:]]
         stop_indices.append(len(sleep_behavior_df) - 1)
         stop_indices = np.array(stop_indices)
 
-        start_frames = sleep_behavior_df['Frame'][start_indices].values
-        start_times = start_frames / self.video_sampling_frequency
-        stop_frames = sleep_behavior_df['Frame'][stop_indices].values
-        stop_times = stop_frames / self.video_sampling_frequency
-        sleep_state = sleep_behavior_df['SleepState'][start_indices].values
+        start_frames = sleep_behavior_df["Frame"][start_indices].values
+        start_times = self._start_times if self._start_times is not None else start_frames / self.sampling_frequency
+        stop_frames = sleep_behavior_df["Frame"][stop_indices].values
+        stop_times = self._stop_times if self._stop_times is not None else stop_frames / self.sampling_frequency
 
+        sleep_state = sleep_behavior_df["SleepState"][start_indices].values
+
+        return start_times, stop_times, sleep_state
+
+    def set_aligned_interval_times(self, start_times: List[float], stop_times: List[float]) -> None:
+        self._start_times = start_times
+        self._stop_times = stop_times
+
+    def add_to_nwbfile(self, nwbfile: NWBFile, metadata: Optional[dict] = None):
+
+        start_times, stop_times, sleep_state = self.get_sleep_states_times()
 
         description = (
             "Sleep states classified with custom algorithm using the data "
             "from the HD-X02 sensor (EEG, EMG, temperature, etc.)."
-        )        
-        
+        )
+
         sleep_intervals = TimeIntervals(name="SleepIntervals", description=description)
         column_description = """
             Sleep State Classification, it can be one of the following: 
@@ -63,7 +73,7 @@ class Zaki2024SleepClassificationInterface(BaseDataInterface):
             - 'wake': State of full consciousness when the animal is alert, responsive to the environment, and capable of voluntary movement
         """
         sleep_intervals.add_column(name="sleep_state", description=column_description)
-        
+
         for start_time, stop_time, state in zip(start_times, stop_times, sleep_state):
             sleep_intervals.add_interval(start_time=start_time, stop_time=stop_time, sleep_state=state)
 
@@ -71,6 +81,5 @@ class Zaki2024SleepClassificationInterface(BaseDataInterface):
             sleep_module = nwbfile.create_processing_module(name="sleep", description="Sleep data")
         else:
             sleep_module = nwbfile.processing["sleep"]
-        
-        sleep_module.add(sleep_intervals)
 
+        sleep_module.add(sleep_intervals)

--- a/src/cai_lab_to_nwb/zaki_2024/zaki_2024_convert_all_sessions.py
+++ b/src/cai_lab_to_nwb/zaki_2024/zaki_2024_convert_all_sessions.py
@@ -122,8 +122,8 @@ if __name__ == "__main__":
     data_dir_path = Path("D:/")
     output_dir_path = Path("D:/cai_lab_conversion_nwb/")
     max_workers = 1
-    verbose = True
-    stub_test = True
+    verbose = False
+    stub_test = False
     dataset_to_nwb(
         data_dir_path=data_dir_path,
         output_dir_path=output_dir_path,

--- a/src/cai_lab_to_nwb/zaki_2024/zaki_2024_convert_session.py
+++ b/src/cai_lab_to_nwb/zaki_2024/zaki_2024_convert_session.py
@@ -186,7 +186,7 @@ if __name__ == "__main__":
     subject_id = "Ca_EEG2-1"
     session_type = "NeutralExposure"  #
     session_id = subject_id + "_" + session_type
-    stub_test = True
+    stub_test = False
     verbose = True
     yaml_file_path = Path(__file__).parent / "utils/conversion_parameters.yaml"
     conversion_parameter_dict = load_dict_from_file(yaml_file_path)

--- a/src/cai_lab_to_nwb/zaki_2024/zaki_2024_convert_session.py
+++ b/src/cai_lab_to_nwb/zaki_2024/zaki_2024_convert_session.py
@@ -1,7 +1,7 @@
 """Primary script to run to convert an entire session for of data using the NWBConverter."""
 
 import time
-
+import pytz
 from pathlib import Path
 from typing import Union
 from datetime import datetime, timedelta
@@ -62,16 +62,16 @@ def session_to_nwb(
         source_data.update(dict(MinianSegmentation=dict(folder_path=minian_folder_path)))
         conversion_options.update(dict(MinianSegmentation=dict(stub_test=stub_test)))
 
-        motion_corrected_video = minian_folder_path / "minian_mc.mp4"
-        if motion_corrected_video.is_file():
-            source_data.update(
-                dict(
-                    MinianMotionCorrection=dict(folder_path=minian_folder_path, video_file_path=motion_corrected_video)
-                )
-            )
-            conversion_options.update(dict(MinianMotionCorrection=dict(stub_test=stub_test)))
-        elif verbose and not motion_corrected_video.is_file():
-            print(f"No motion corrected data found at {motion_corrected_video}")
+        # motion_corrected_video = minian_folder_path / "minian_mc.mp4"
+        # if motion_corrected_video.is_file():
+        #     source_data.update(
+        #         dict(
+        #             MinianMotionCorrection=dict(folder_path=minian_folder_path, video_file_path=motion_corrected_video)
+        #         )
+        #     )
+        #     conversion_options.update(dict(MinianMotionCorrection=dict(stub_test=stub_test)))
+        # elif verbose and not motion_corrected_video.is_file():
+        #     print(f"No motion corrected data found at {motion_corrected_video}")
 
     # Add Behavioral Video
     if video_file_path:
@@ -133,7 +133,7 @@ def session_to_nwb(
         sleep_classification_file_path = Path(sleep_classification_file_path)
         assert sleep_classification_file_path.is_file(), f"{sleep_classification_file_path} does not exist"
         source_data.update(
-            dict(SleepClassification=dict(file_path=sleep_classification_file_path, video_sampling_frequency=30.0))
+            dict(SleepClassification=dict(file_path=sleep_classification_file_path, sampling_frequency=15.0))
         )
 
     # Add Shock Stimuli times for FC sessions
@@ -153,6 +153,9 @@ def session_to_nwb(
         datetime_str = date_str + " " + time_str
         session_start_time = datetime.strptime(datetime_str, "%Y_%m_%d %H_%M_%S")
         metadata["NWBFile"]["session_start_time"] = session_start_time
+
+    eastern = pytz.timezone("US/Eastern")
+    metadata["NWBFile"]["session_start_time"] = eastern.localize(metadata["NWBFile"]["session_start_time"])
 
     # Update default metadata with the editable in the corresponding yaml file
     editable_metadata_path = Path(__file__).parent / "zaki_2024_metadata.yaml"
@@ -180,10 +183,10 @@ def session_to_nwb(
 
 if __name__ == "__main__":
 
-    subject_id = "Ca_EEG3-4"
-    session_type = "OfflineDay2Session1"
+    subject_id = "Ca_EEG2-1"
+    session_type = "NeutralExposure"  #
     session_id = subject_id + "_" + session_type
-    stub_test = False
+    stub_test = True
     verbose = True
     yaml_file_path = Path(__file__).parent / "utils/conversion_parameters.yaml"
     conversion_parameter_dict = load_dict_from_file(yaml_file_path)

--- a/src/cai_lab_to_nwb/zaki_2024/zaki_2024_convert_session.py
+++ b/src/cai_lab_to_nwb/zaki_2024/zaki_2024_convert_session.py
@@ -31,8 +31,9 @@ def session_to_nwb(
     sleep_classification_file_path: Union[str, Path] = None,
     shock_stimulus: dict = None,
 ):
-    print(f"Converting session {session_id}")
+
     if verbose:
+        print(f"Converting session {session_id}")
         start = time.time()
 
     output_dir_path = Path(output_dir_path)
@@ -87,9 +88,9 @@ def session_to_nwb(
         source_data.update(
             dict(FreezingBehavior=dict(file_path=freezing_output_file_path, video_sampling_frequency=30.0))
         )
+        conversion_options.update(dict(FreezingBehavior=dict(stub_test=stub_test)))
 
     # Add EEG, EMG, Temperature and Activity signals
-
     if edf_file_path:
         edf_file_path = Path(edf_file_path)
         assert edf_file_path.is_file(), f"{edf_file_path} does not exist"
@@ -144,7 +145,7 @@ def session_to_nwb(
             ShockStimuli=shock_stimulus,
         )
 
-    converter = Zaki2024NWBConverter(source_data=source_data)
+    converter = Zaki2024NWBConverter(source_data=source_data, verbose=verbose)
 
     # Add datetime to conversion
     metadata = converter.get_metadata()
@@ -184,9 +185,9 @@ def session_to_nwb(
 if __name__ == "__main__":
 
     subject_id = "Ca_EEG2-1"
-    session_type = "NeutralExposure"  #
+    session_type = "FC"  #
     session_id = subject_id + "_" + session_type
-    stub_test = False
+    stub_test = True
     verbose = True
     yaml_file_path = Path(__file__).parent / "utils/conversion_parameters.yaml"
     conversion_parameter_dict = load_dict_from_file(yaml_file_path)

--- a/src/cai_lab_to_nwb/zaki_2024/zaki_2024_nwbconverter.py
+++ b/src/cai_lab_to_nwb/zaki_2024/zaki_2024_nwbconverter.py
@@ -82,3 +82,20 @@ class Zaki2024NWBConverter(NWBConverter):
                 if "EDFSignals" in self.data_interface_objects:
                     edf_signals_interface = self.data_interface_objects["EDFSignals"]
                     edf_signals_interface.set_aligned_starting_time(time_shift)
+
+                if "FreezingBehavior" in self.data_interface_objects:
+                    freezing_behavior_interface = self.data_interface_objects["FreezingBehavior"]
+                    start_times, stop_times = freezing_behavior_interface.get_interval_times()
+                    start_times += time_shift
+                    stop_times += time_shift
+                    freezing_behavior_interface.set_aligned_interval_times(
+                        start_times=start_times, stop_times=stop_times
+                    )
+                    starting_time = freezing_behavior_interface.get_starting_time()
+                    freezing_behavior_interface.set_aligned_starting_time(starting_time + time_shift)
+
+                if "Video" in self.data_interface_objects:
+                    video_interface = self.data_interface_objects["Video"]
+                    video_timestamps = video_interface.get_original_timestamps()
+                    aligned_video_timestamps = video_timestamps + time_shift
+                    video_interface.set_aligned_timestamps(aligned_video_timestamps)

--- a/src/cai_lab_to_nwb/zaki_2024/zaki_2024_nwbconverter.py
+++ b/src/cai_lab_to_nwb/zaki_2024/zaki_2024_nwbconverter.py
@@ -60,7 +60,6 @@ class Zaki2024NWBConverter(NWBConverter):
             if imaging_timestamps[0] < 0.0:
                 time_shift = abs(imaging_timestamps[0])
                 imaging_interface.set_aligned_timestamps(imaging_timestamps + time_shift)
-
                 if "MinianSegmentation" in self.data_interface_objects:
                     segmentation_interface = self.data_interface_objects["MinianSegmentation"]
                     segmentation_timestamps = segmentation_interface.get_original_timestamps()

--- a/src/cai_lab_to_nwb/zaki_2024/zaki_2024_nwbconverter.py
+++ b/src/cai_lab_to_nwb/zaki_2024/zaki_2024_nwbconverter.py
@@ -68,7 +68,7 @@ class Zaki2024NWBConverter(NWBConverter):
                 # if "MinianMotionCorrection" in self.data_interface_objects:
                 #     motion_correction_interface = self.data_interface_objects["MinianMotionCorrection"]
                 #     motion_correction_timestamps = motion_correction_interface.get_original_timestamps()
-                #     motion_correction_interface.set_aligned_timestamps(segmentation_timestamps + time_shift)
+                #     motion_correction_interface.set_aligned_timestamps(motion_correction_timestamps + time_shift)
 
                 if "SleepClassification" in self.data_interface_objects:
                     sleep_classification_interface = self.data_interface_objects["SleepClassification"]

--- a/src/cai_lab_to_nwb/zaki_2024/zaki_2024_nwbconverter.py
+++ b/src/cai_lab_to_nwb/zaki_2024/zaki_2024_nwbconverter.py
@@ -79,3 +79,6 @@ class Zaki2024NWBConverter(NWBConverter):
                     sleep_classification_interface.set_aligned_interval_times(
                         start_times=start_times, stop_times=stop_times
                     )
+                if "EDFSignals" in self.data_interface_objects:
+                    edf_signals_interface = self.data_interface_objects["EDFSignals"]
+                    edf_signals_interface.set_aligned_starting_time(time_shift)

--- a/src/cai_lab_to_nwb/zaki_2024/zaki_2024_nwbconverter.py
+++ b/src/cai_lab_to_nwb/zaki_2024/zaki_2024_nwbconverter.py
@@ -60,3 +60,13 @@ class Zaki2024NWBConverter(NWBConverter):
             if imaging_timestamps[0] < 0.0:
                 time_shift = abs(imaging_timestamps[0])
                 imaging_interface.set_aligned_timestamps(imaging_timestamps + time_shift)
+
+                if "MinianSegmentation" in self.data_interface_objects:
+                    segmentation_interface = self.data_interface_objects["MinianSegmentation"]
+                    segmentation_timestamps = segmentation_interface.get_original_timestamps()
+                    segmentation_interface.set_aligned_timestamps(segmentation_timestamps + time_shift)
+
+                # if "MinianMotionCorrection" in self.data_interface_objects:
+                #     motion_correction_interface = self.data_interface_objects["MinianMotionCorrection"]
+                #     motion_correction_timestamps = motion_correction_interface.get_original_timestamps()
+                #     motion_correction_interface.set_aligned_timestamps(segmentation_timestamps + time_shift)

--- a/src/cai_lab_to_nwb/zaki_2024/zaki_2024_nwbconverter.py
+++ b/src/cai_lab_to_nwb/zaki_2024/zaki_2024_nwbconverter.py
@@ -70,3 +70,12 @@ class Zaki2024NWBConverter(NWBConverter):
                 #     motion_correction_interface = self.data_interface_objects["MinianMotionCorrection"]
                 #     motion_correction_timestamps = motion_correction_interface.get_original_timestamps()
                 #     motion_correction_interface.set_aligned_timestamps(segmentation_timestamps + time_shift)
+
+                if "SleepClassification" in self.data_interface_objects:
+                    sleep_classification_interface = self.data_interface_objects["SleepClassification"]
+                    start_times, stop_times, sleep_states = sleep_classification_interface.get_sleep_states_times()
+                    start_times += time_shift
+                    stop_times += time_shift
+                    sleep_classification_interface.set_aligned_interval_times(
+                        start_times=start_times, stop_times=stop_times
+                    )


### PR DESCRIPTION
To review after merging #22
Everything should be aligned to the miniscope data recording start time. 
Sometimes the first timestamps of the miniscope imaging data are negative. 
Thus we need to shift back the recording start time, taking the first negative timestamp as time shift.
When shiting back the recording start time, that is the session start time, all the other traces need to shift forward by the same time shift.

run nwbinspector on nwb file generated with this code version:

 